### PR TITLE
[FEATURE] 여행 계획 삭제 로직 개발

### DIFF
--- a/src/main/java/com/ssafy/planner/service/PlannerServiceImpl.java
+++ b/src/main/java/com/ssafy/planner/service/PlannerServiceImpl.java
@@ -128,8 +128,6 @@ public class PlannerServiceImpl implements PlannerService {
 
   @Override
   public void deletePlanner(Long plannerId, CustomUserDetails loginUser) {
-    scheduleMapper.deleteSchedulesByPlanner(plannerId);
-
     int cnt = plannerMapper.deletePlanner(plannerId);
 
     if (cnt != 1) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -176,7 +176,7 @@ CREATE TABLE `planners_locations`
     -- 플래너 참조
     CONSTRAINT `fk_planners_locations_planner`
       FOREIGN KEY (`planner_id`)
-      REFERENCES `planners` (`id`),
+      REFERENCES `planners` (`id`) ON DELETE CASCADE,
     -- 시도 참조
     CONSTRAINT `fk_planners_locations_sido`
       FOREIGN KEY (`sido_code`)
@@ -194,7 +194,7 @@ CREATE TABLE `planners_likes`
     `planner_id` BIGINT NOT NULL,
     `member_id`  BIGINT NOT NULL,
     PRIMARY KEY (`id`),
-    FOREIGN KEY (`planner_id`) REFERENCES `planners` (`id`),
+    FOREIGN KEY (`planner_id`) REFERENCES `planners` (`id`) ON DELETE CASCADE,
     FOREIGN KEY (`member_id`) REFERENCES `members` (`id`)
 );
 
@@ -205,7 +205,7 @@ CREATE TABLE `planners_members`
     `planner_id` BIGINT NOT NULL,
     `member_id`  BIGINT NOT NULL,
     PRIMARY KEY (`id`),
-    FOREIGN KEY (`planner_id`) REFERENCES `planners` (`id`),
+    FOREIGN KEY (`planner_id`) REFERENCES `planners` (`id`) ON DELETE CASCADE,
     FOREIGN KEY (`member_id`) REFERENCES `members` (`id`)
 );
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -241,7 +241,7 @@ CREATE TABLE  `schedules`
     `idx`        INT    NOT NULL,
     `place_id`   BIGINT NOT NULL,
     PRIMARY KEY (`id`, `planner_id`),
-    FOREIGN KEY (`planner_id`) REFERENCES `planners` (`id`),
+    FOREIGN KEY (`planner_id`) REFERENCES `planners` (`id`) ON DELETE CASCADE,
     FOREIGN KEY (`place_id`) REFERENCES `places` (`id`)
 );
 


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
planner의 자식 테이블의 외래키 제약에 CASCADE 설정

## 이슈 링크
close #28

## 참고사항
- 서비스 단에서 일일이 플래너의 자식 테이블 데이터를 지우는 작업을 하는 방안과 ON DELETE CASCADE를 사용하는 방안 중에 후자를 선택했습니다.
- 혹시 전자가 더 낫다고 생각되시면 코멘트 남겨주세요.
