### PR TITLE
[BUGFIX] data.sql 실행 오류 수정 

### DIFF
--- a/src/main/java/com/ssafy/initializer/DummyDataInitializer.java
+++ b/src/main/java/com/ssafy/initializer/DummyDataInitializer.java
@@ -1,0 +1,37 @@
+package com.ssafy.initializer;
+
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(2)
+public class DummyDataInitializer implements ApplicationRunner {
+
+  private final DataSource dataSource;
+
+  /**
+   * 애플리케이션 시작 시 data.sql로부터 더미 데이터를 초기화합니다.
+   */
+  @Override
+  public void run(ApplicationArguments args) {
+    try {
+      log.info("[INIT] Now loading Dummy Data...");
+      ResourceDatabasePopulator pop = new ResourceDatabasePopulator();
+      pop.addScript(new ClassPathResource("data.sql"));
+      pop.setSeparator(";");
+      pop.execute(dataSource);
+      log.info("[INIT] data.sql has been applied.");
+    } catch (Exception e) {
+      log.error("[INIT:ERROR] Dummy Data initialization FAILED: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/com/ssafy/initializer/LocationDataInitializer.java
+++ b/src/main/java/com/ssafy/initializer/LocationDataInitializer.java
@@ -6,23 +6,21 @@ import com.ssafy.location.dto.Sido;
 import com.ssafy.location.service.LocationService;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Order(1)
 public class LocationDataInitializer implements ApplicationRunner {
 
   private final LocationService locationService;
   private final LocationDataClient locationDataClient;
-  private final DataSource dataSource;
 
   /**
    * 애플리케이션 시작 시 API로부터 시도 및 구군 데이터를 초기화합니다.
@@ -30,7 +28,7 @@ public class LocationDataInitializer implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) {
     try {
-      log.info("[INIT] Start to load initial data");
+      log.info("[INIT] Start to load initial Location Data");
 
       // 시도 정보가 DB에 없는 경우에만 호출
       if (locationService.getAllSidos()
@@ -69,20 +67,12 @@ public class LocationDataInitializer implements ApplicationRunner {
             locationService.insertAllGuguns(gugunList);
           }
         }
-        log.info("[INIT] Data initialization completed.");
+        log.info("[INIT] Location Data initialization completed.");
       } else {
-        log.info("[INIT] Data already exists. Skipping API fetch.");
+        log.info("[INIT] Location Data already exists. Skipping API fetch.");
       }
-
-      log.info("[INIT] Now loading dummy data...");
-      ResourceDatabasePopulator pop = new ResourceDatabasePopulator();
-      pop.addScript(new ClassPathResource("data.sql"));
-      pop.setSeparator(";");
-      pop.execute(dataSource);
-      log.info("[INIT] data.sql has been applied.");
-
     } catch (Exception e) {
-      log.error("[INIT:ERROR] Data initialization failed: {}", e.getMessage(), e);
+      log.error("[INIT:ERROR] Location Data initialization FAILED: {}", e.getMessage(), e);
     }
   }
 }

--- a/src/main/java/com/ssafy/initializer/LocationDataInitializer.java
+++ b/src/main/java/com/ssafy/initializer/LocationDataInitializer.java
@@ -1,4 +1,4 @@
-package com.ssafy.location.runner;
+package com.ssafy.initializer;
 
 import com.ssafy.location.api.LocationDataClient;
 import com.ssafy.location.dto.Gugun;

--- a/src/main/java/com/ssafy/location/runner/LocationDataInitializer.java
+++ b/src/main/java/com/ssafy/location/runner/LocationDataInitializer.java
@@ -6,10 +6,13 @@ import com.ssafy.location.dto.Sido;
 import com.ssafy.location.service.LocationService;
 import java.util.ArrayList;
 import java.util.List;
+import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -19,6 +22,7 @@ public class LocationDataInitializer implements ApplicationRunner {
 
   private final LocationService locationService;
   private final LocationDataClient locationDataClient;
+  private final DataSource dataSource;
 
   /**
    * 애플리케이션 시작 시 API로부터 시도 및 구군 데이터를 초기화합니다.
@@ -69,6 +73,14 @@ public class LocationDataInitializer implements ApplicationRunner {
       } else {
         log.info("[INIT] Data already exists. Skipping API fetch.");
       }
+
+      log.info("[INIT] Now loading dummy data...");
+      ResourceDatabasePopulator pop = new ResourceDatabasePopulator();
+      pop.addScript(new ClassPathResource("data.sql"));
+      pop.setSeparator(";");
+      pop.execute(dataSource);
+      log.info("[INIT] data.sql has been applied.");
+
     } catch (Exception e) {
       log.error("[INIT:ERROR] Data initialization failed: {}", e.getMessage(), e);
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,3 @@
--- Add dummy data
--- SIDOS/GUGUNS will be fetched by tour API
--- 서버 최초 구동 시 아래 내용 모두 주석 처리 후 진행해주세요.
-
 -- MEMBERS
 INSERT INTO members (email, password, name, role, birth, mbti, refresh_token)
 VALUES ('test@test.com', '$2a$10$.k8PcfjUA0KTJf3AK0lbD.FqrxsqJBoB6gn2khl2vjhlM51fkcOxe', 'test',


### PR DESCRIPTION
## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- 작업 순서가 schema.sql -> data.sql -> API data fetch 순이라 더미 데이터 삽입에 귀찮음이 있었음 (매번 data.sql 주석 처리)
- 그러나 기존 truncate문을 drop문으로 schema.sql에 옮기면서 data.sql의 insert문을 주석처리 후 서버 구동 시 data.sql 가 비어있어 에러 발생
- 따라서 application.properties에서 **schema.sql만 실행**하게 설정하고(data.sql 실행X) data.sql은 **api fetch/skip 후 수동으로 data.sql 스크립트를 불러오게** 수정

## 이슈 링크
close #33

## 참고사항
- 코드나 흐름 관련해서 이해 안되시는 부분 있으시면 코멘트 주세요.
.
.
.
- 고민되는 부분이 있습니다.. 이렇게 되면 LocationDataInitializer에서 **location 관련 데이터 뿐만 아니라 더미 데이터도 삽입하게 되는데 그럼 이 initializer을 location 패키지 밖으로 빼는 게 맞나** 하는 생각이 드네요..
  - 구조적으로 수정하는 것이 맞긴 한 것 같은데
  - 어차피 개발 단계 이후에는 더미 데이터를 사용할 일이 없고 LocationDataInitializer에서는 기존처럼 시도, 구군만 패치해오면 되니 굳이 구조를 수정해야하나 싶기도 하고요..

- 의견 부탁드립니다.
